### PR TITLE
pyogrio 0.10.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-$PYTHON -m pip install . -vv
+$PYTHON -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,7 @@ build:
 
 requirements:
   build:
+    - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,34 +10,47 @@ source:
   sha256: ec051cb568324de878828fae96379b71858933413e185148acb6c162851ab23c
 
 build:
-  number: 1
-  skip: true  # [py<38 or python_impl == 'pypy']
+  number: 0
+  skip: true  # [py<39]
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - cython                                 # [build_platform != target_platform]
     - {{ compiler('c') }}
-    - {{ stdlib("c") }}
     - {{ compiler('cxx') }}
   host:
     - python
     - pip
     - setuptools
-    - cython
-    - libgdal-core
-    - versioneer
-    - tomli  # [py<311]
+    - cython >=0.29
+    # https://github.com/geopandas/pyogrio/blob/v0.10.0/setup.py#L24
+    - libgdal >=2.4.0
+    # https://github.com/geopandas/pyogrio/blob/v0.10.0/pyproject.toml#L5
+    - versioneer ==0.28
+    - tomli 2.0.1 # [py<311]
   run:
     - python
-    - libgdal-core
+    - libgdal
+    # https://github.com/geopandas/pyogrio/blob/v0.10.0/pyproject.toml#L31
+    - certifi
     - packaging
     - numpy
 
 test:
   imports:
     - pyogrio
+  requires:
+    - pip
+    - pytest
+  source_files:
+    - pyogrio/tests
+  commands:
+    - pip check
+    # Check that pip gets the correct version 
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    # Skip tests that require a network connection
+    # and tests that require the Arrow write API
+    # https://github.com/geopandas/pyogrio/blob/v0.10.0/setup.cfg#L5-L6
+    - pytest -vv -m "not (network or requires_arrow_write_api)" pyogrio/tests
 
 about:
   home: https://github.com/geopandas/pyogrio/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,14 +24,14 @@ requirements:
     - setuptools
     - cython >=0.29
     # https://github.com/geopandas/pyogrio/blob/v0.10.0/setup.py#L24
-    - libgdal >=2.4.0
+    - libgdal {{ libgdal }}
     # Use versioneer 0.29 for py313 instead of 0.28
     # https://github.com/geopandas/pyogrio/blob/v0.10.0/pyproject.toml#L5
-    - versioneer ==0.29
-    - tomli 2.0.1  # [py<311]
+    - versioneer
+    - tomli  # [py<311]
   run:
     - python
-    - libgdal
+    - libgdal # bounds through run_exports
     # https://github.com/geopandas/pyogrio/blob/v0.10.0/pyproject.toml#L31
     - certifi
     - packaging

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<39]
+  # skip s390x: no libgdal
+  skip: true  # [py<39 or s390x]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,9 @@ requirements:
     - cython >=0.29
     # https://github.com/geopandas/pyogrio/blob/v0.10.0/setup.py#L24
     - libgdal >=2.4.0
+    # Use versioneer 0.29 for py313 instead of 0.28
     # https://github.com/geopandas/pyogrio/blob/v0.10.0/pyproject.toml#L5
-    - versioneer ==0.28
+    - versioneer ==0.29
     - tomli 2.0.1  # [py<311]
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,6 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
     - python
@@ -26,7 +25,7 @@ requirements:
     - libgdal >=2.4.0
     # https://github.com/geopandas/pyogrio/blob/v0.10.0/pyproject.toml#L5
     - versioneer ==0.28
-    - tomli 2.0.1 # [py<311]
+    - tomli 2.0.1  # [py<311]
   run:
     - python
     - libgdal


### PR DESCRIPTION
pyogrio 0.10.0

**Destination channel:** defaults

### Links

- [PKG-6410]
- dev_url (recipe): https://github.com/geopandas/pyogrio/tree/v0.10.0  
- pypi: https://pypi.org/project/pyogrio/0.10.0  
- pypi inspector: https://inspector.pypi.io/project/pyogrio/0.10.0  
- conda-forge: https://github.com/conda-forge/pyogrio-feedstock  

### Explanation of changes:

- bump version
- add upstream tests
- `tomli` has `2.0.1` version in `host` to have a pin, not found in upstream.
- use `versioneer 0.29` instead of `versioneer 0.28` to build py313 variant

[PKG-6410]: https://anaconda.atlassian.net/browse/PKG-6410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ